### PR TITLE
Implemented intial geocoded location logic

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/benmirtchouk/CS-554-Car-Site#readme",
   "dependencies": {
+    "apollo-datasource-mongodb": "^0.5.2",
     "apollo-datasource-rest": "^3.4.0",
     "apollo-server": "^3.5.0",
     "apollo-server-cache-redis": "^3.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "seed": "node src/tasks/seed.js"
   },
   "repository": {
     "type": "git",
@@ -24,6 +25,7 @@
     "apollo-server-plugin-response-cache": "^3.4.0",
     "dotenv": "^10.0.0",
     "graphql": "^15.7.2",
-    "ioredis": "^4.28.0"
+    "ioredis": "^4.28.0",
+    "mongodb": "^4.2.0"
   }
 }

--- a/server/src/DataModel/GeoJson/GeoJsonPoint.js
+++ b/server/src/DataModel/GeoJson/GeoJsonPoint.js
@@ -1,0 +1,9 @@
+const { GeoJsonType } = require("./GeoJsonType");
+
+class GeoJsonPoint extends GeoJsonType {
+    constructor(coordinates) {
+        super(coordinates, "Point");
+    }
+}
+
+module.exports = GeoJsonPoint;

--- a/server/src/DataModel/GeoJson/GeoJsonType.js
+++ b/server/src/DataModel/GeoJson/GeoJsonType.js
@@ -1,0 +1,64 @@
+
+/// Abstract base class for all GeoJsonTypes supported by Mongo. This class performs the validation that points
+/// are correctly formatted, within valid bounds, and that each property is established
+class GeoJsonType {
+
+    /// coordinates formats are: an array of two floats (longitude first), or an object with longitude and latitude keys
+    ///    Longitude must be in the range [-180, 180] and latitude [-90, 90]
+    /// Type must be a supported type in Mongo *and* have a valid sub class for logic 
+    constructor(coordinates, type) {
+        if(this.constructor === GeoJsonType) {
+            throw new Error("GeoJsonType is abstract and should not be instantiated directly!")
+        }
+
+        if(!coordinates) {
+            throw new InvalidCoordinateType("Co-ordinates parameter cannot be null");
+        }
+        
+        /// Normalize between both potential input formats
+        const normalizedCoordinates = Array.isArray(coordinates) ? coordinates : [coordinates.longitude, coordinates.latitude].filter(e => e != null)
+        
+        if( normalizedCoordinates.length !== 2 ) {
+            throw new InvalidCoordinateType("Co-ordinates parameter is not a GeoJson coordinates object!")
+        }
+
+        const [longitude, latitude] = normalizedCoordinates;
+        const abs = Math.abs;
+
+        /// Validate Longitude and Latitude are in the correct bounds
+        const maxLongitude = 180;
+        if( !isFinite(longitude) || abs(longitude) - maxLongitude > 0  ) {
+            throw new InvalidCoordinateType("Longitude must be a number between -180 and 180");
+        }
+        this.longitude = longitude
+
+        const maxLatitude = 90;
+        if (!isFinite(latitude) || abs(latitude) - maxLatitude > 0) {
+            throw new InvalidCoordinateType("Latitude must be a number between -90 and 90");
+        }
+
+        this.latitude = latitude;
+
+        /// Populate properties
+        this.coordinateArray = [longitude, latitude]
+        this.coordinateJson = { longitude: longitude, latitude: latitude}
+
+        /// Full valid types are https://docs.mongodb.com/manual/reference/geojson/
+        /// Currently set to only Point as that is the only logic implemented. If a new sub class is added,
+        /// Update this array and ensure all base class logic works correctly for the new type.
+        const validTypes = new Set(["Point"])
+        if (typeof type !== 'string' || !validTypes.has(type)) {
+            throw new Error("Specified type is not a supported GeoJSONtype");
+        }
+        this.type = type;
+    }
+}
+
+/// Thrown on any cases where a co-ordinate type is incorrect
+class InvalidCoordinateType extends Error { }
+
+
+module.exports = {
+    GeoJsonType,
+    InvalidCoordinateType
+}

--- a/server/src/GraphQL/DataSources/GeocodedLocationDataSource.js
+++ b/server/src/GraphQL/DataSources/GeocodedLocationDataSource.js
@@ -36,6 +36,21 @@ class GeocodedLocationDataSource extends MongoDataSource {
                 .map(e => new GeoJsonPoint(e.location.coordinates))
     }
 
+
+    async insertPoint(point) {
+        if (! (point instanceof GeoJsonPoint) ) { throw new Error("Center point must be a GeoJson point!")}
+        
+        const value = {
+            location: {
+                type: "Point",
+                coordinates: point.coordinateArray
+            }
+        }
+
+        /// TODO Upsert?
+        await this.collection.insertOne(value);
+    }
+
 }
 
 module.exports = GeocodedLocationDataSource;

--- a/server/src/GraphQL/DataSources/GeocodedLocationDataSource.js
+++ b/server/src/GraphQL/DataSources/GeocodedLocationDataSource.js
@@ -1,0 +1,40 @@
+const { MongoDataSource } = require('apollo-datasource-mongodb');
+const { UserInputError } = require('apollo-server-errors');
+
+
+class GeocodedLocationDataSource extends MongoDataSource {
+
+    milesToRadian(miles) {
+        if(!isFinite(miles) || miles < 0) { throw new UserInputError("Provided miles must be a non-negative number")}
+        /// https://docs.mongodb.com/manual/tutorial/calculate-distances-using-spherical-geometry-with-2d-geospatial-indexes/
+        const earthRadiusInMiles = 3963.2;
+        return miles / earthRadiusInMiles;
+    };
+
+
+
+    async locationsWithinMileRadius(centerPoint, radius) {
+        return await this.locationsWithinRadianRadius(centerPoint, this.milesToRadian(radius))
+    }
+
+
+    async locationsWithinRadianRadius(centerPoint, radius) {
+        if (!isFinite(radius) || radius < 0) { throw new UserInputError("Radians must be non negative!"); }
+        const results = (await this.collection.find({
+            location: { 
+                $geoWithin: { 
+                    $centerSphere: [ centerPoint, radius ] 
+                } 
+            }
+
+        })
+        .toArray())
+
+        return results
+                .map(e => e.location.coordinates)
+                .map(e => { return { longitude: e[0], latitude:e[1] }})
+    }
+
+}
+
+module.exports = GeocodedLocationDataSource;

--- a/server/src/GraphQL/DataSources/index.js
+++ b/server/src/GraphQL/DataSources/index.js
@@ -1,1 +1,2 @@
 exports.NHSTADataSource = require('./NHSTADataSource');
+exports.GeocodedLocationDataSource = require('./GeocodedLocationDataSource');

--- a/server/src/GraphQL/dataSources.js
+++ b/server/src/GraphQL/dataSources.js
@@ -1,7 +1,9 @@
-const { NHSTADataSource } = require('./DataSources')
+const { NHSTADataSource, GeocodedLocationDataSource } = require('./DataSources')
+const { geocode } = require('../config/mongoCollections');
 
-const dataSources = () => ({
+const dataSources = async () => ({
     nhsta: new NHSTADataSource.NHSTADataSource(),
+    geocoded: new GeocodedLocationDataSource(await geocode())
   })
 
 

--- a/server/src/GraphQL/resolvers.js
+++ b/server/src/GraphQL/resolvers.js
@@ -1,14 +1,60 @@
+/// TODO MOVE
+const { geocode } = require("../config/mongoCollections");
+
 
 const resolvers = {
     Query: {
         vehicleBy: async (parent, args, { dataSources }) => {
             return await dataSources.nhsta.vinQueryURL(args.vin);
+        },
+
+        getPointsBy: async(parent, args) => {
+
+            const milesToRadian = function(miles){
+                const earthRadiusInMiles = 3963;
+                return miles / earthRadiusInMiles;
+            };
+            
+
+
+            const point = args.point;
+            const pointArray = [point.longitude, point.latitude];
+            const radius = milesToRadian(args.radius);
+            console.log(pointArray)
+            console.log(radius);
+            const geocodeCollection = await geocode();
+            const returnedPoints = (await geocodeCollection.find({
+                location: { 
+                    $geoWithin: { 
+                        $centerSphere: [ pointArray, radius ] 
+                    } 
+                }
+
+            })
+            .toArray())
+            .map(e => e.location.coordinates)
+            .map(e => { return { longitude: e[0], latitude:e[1] }})
+
+            console.log(JSON.stringify(returnedPoints));
+
+            return returnedPoints;
         }
 
     },
     Mutation: {
         modifyPlaceHolder: async (parent, args) => {
             return {placeholder: "Hello World!"}
+        },
+        addPoint: async (parent, args) => {
+            
+            const point = args.point;
+            console.log(point.longitude)
+            console.log(point.latitude)
+            const geocodeCollection = await geocode();
+            /// TODO Upsert?
+            await geocodeCollection.insertOne(point);
+
+            return point;
         }
     }
 };

--- a/server/src/GraphQL/resolvers.js
+++ b/server/src/GraphQL/resolvers.js
@@ -4,37 +4,16 @@ const { geocode } = require("../config/mongoCollections");
 
 const resolvers = {
     Query: {
-        vehicleBy: async (parent, args, { dataSources }) => {
+        vehicleBy: async (parent, args, { dataSources })  => {
             return await dataSources.nhsta.vinQueryURL(args.vin);
         },
 
-        getPointsBy: async(parent, args) => {
-
-            const milesToRadian = function(miles){
-                const earthRadiusInMiles = 3963;
-                return miles / earthRadiusInMiles;
-            };
-            
-
+        getPointsBy: async(parent, args, { dataSources }) => {
 
             const point = args.point;
             const pointArray = [point.longitude, point.latitude];
-            const radius = milesToRadian(args.radius);
-            console.log(pointArray)
-            console.log(radius);
-            const geocodeCollection = await geocode();
-            const returnedPoints = (await geocodeCollection.find({
-                location: { 
-                    $geoWithin: { 
-                        $centerSphere: [ pointArray, radius ] 
-                    } 
-                }
 
-            })
-            .toArray())
-            .map(e => e.location.coordinates)
-            .map(e => { return { longitude: e[0], latitude:e[1] }})
-
+            const returnedPoints = await dataSources.geocoded.locationsWithinMileRadius(pointArray, args.radius)
             console.log(JSON.stringify(returnedPoints));
 
             return returnedPoints;

--- a/server/src/GraphQL/typeDefs.js
+++ b/server/src/GraphQL/typeDefs.js
@@ -15,10 +15,13 @@ directive @cacheControl(
 
 type Query {
     vehicleBy(vin: String!): Vehicle @cacheControl(maxAge: 240, scope: PUBLIC)
+    getPointsBy(point: GeocodedPointInput!, radius: Int!): [GeocodedPoint]
+
 }
 
 type Mutation {
     modifyPlaceHolder(placeholder: String!): Placeholder
+    addPoint(point: GeocodedPointInput!): GeocodedPoint!
 }
 
 
@@ -32,6 +35,16 @@ type Vehicle @cacheControl(maxAge: 240) {
     manufacturer: String!
     model: String!
     year: Int!
+}
+
+type GeocodedPoint {
+    longitude: Float!
+    latitude: Float! 
+}
+
+input GeocodedPointInput {
+    longitude: Float!
+    latitude: Float! 
 }
 `;
 

--- a/server/src/config/mongoCollections.js
+++ b/server/src/config/mongoCollections.js
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Provided from lecture notes of CS546
+ ******************************************************************************/
+ const dbConnection = require("./mongoConnection");
+
+ /* This will allow you to have one reference to each collection per app */
+ /* Feel free to copy and paste this this */
+ const getCollectionFn = (collection) => {
+     let _col = undefined;
+ 
+     return async () => {
+         if (!_col) {
+             const db = await dbConnection();
+             _col = await db.collection(collection);
+         }
+ 
+         return _col;
+     };
+ };
+ 
+ /* Now, you can list your collections here: */
+ module.exports = {
+    geocode: getCollectionFn("geocode")
+ };
+ 

--- a/server/src/config/mongoCollections.js
+++ b/server/src/config/mongoCollections.js
@@ -1,17 +1,21 @@
 /*******************************************************************************
- * Provided from lecture notes of CS546
+ * Base provided from lecture notes of CS546.
  ******************************************************************************/
  const dbConnection = require("./mongoConnection");
 
  /* This will allow you to have one reference to each collection per app */
  /* Feel free to copy and paste this this */
- const getCollectionFn = (collection) => {
+ const getCollectionFn = (collection, indexCreationObject) => {
      let _col = undefined;
  
      return async () => {
          if (!_col) {
              const db = await dbConnection();
              _col = await db.collection(collection);
+
+             if(indexCreationObject && typeof indexCreationObject === 'object') {
+                await _col.createIndex( indexCreationObject)
+             }
          }
  
          return _col;
@@ -20,6 +24,6 @@
  
  /* Now, you can list your collections here: */
  module.exports = {
-    geocode: getCollectionFn("geocode")
+    geocode: getCollectionFn("geocode", { location : "2dsphere" } )
  };
  

--- a/server/src/config/mongoConnection.js
+++ b/server/src/config/mongoConnection.js
@@ -2,7 +2,7 @@ const MongoClient = require("mongodb").MongoClient;
 const settings = {
     mongoConfig: {
         serverUrl: "mongodb://localhost:27017/",
-        database: "carigs_list",
+        database: "Carigslist",
     },
 };
 const mongoConfig = settings.mongoConfig;

--- a/server/src/config/mongoConnection.js
+++ b/server/src/config/mongoConnection.js
@@ -1,0 +1,25 @@
+const MongoClient = require("mongodb").MongoClient;
+const settings = {
+    mongoConfig: {
+        serverUrl: "mongodb://localhost:27017/",
+        database: "carigs_list",
+    },
+};
+const mongoConfig = settings.mongoConfig;
+
+let _connection = undefined;
+let _db = undefined;
+
+module.exports = async () => {
+    if (!_connection) {
+        _connection = await MongoClient.connect(mongoConfig.serverUrl, {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+        });
+        _db = await _connection.db(mongoConfig.database);
+    }
+
+    _db.closeConnection = _connection.close;
+
+    return _db;
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -3,15 +3,31 @@ const {ApolloServer} = require('apollo-server')
 const { typeDefs, resolvers, dataSources, redisCaching} = require('./GraphQL')
 
 
-const server = new ApolloServer({ 
+
+
+
+const startServer = async () => {
+
+  /// Apollo Server does not correctly handle async sources due to constant re-requesting of the property.
+  /// As all uses of the async are for lazy network connections, run them once at start-up, and return those
+  /// resolved references in a wrapper. 
+  console.log("Resolving async data sources...")
+  const sources = await dataSources()
+  const dataSourcesWrapper = () => { return sources; }
+  console.log("Async data sources resolved, continuing start-up of server");
+
+
+  const server = new ApolloServer({ 
     typeDefs,
     resolvers,
-    dataSources,
+    dataSources: dataSourcesWrapper,
     cache: redisCaching
-});
+  });
+
+  server.listen().then(({ url }) => {
+    console.log(`🚀  Server ready at ${url} 🚀`);
+  });
+}
 
 
-//(new Redis()).set("foo", "bar");
-server.listen().then(({ url }) => {
-  console.log(`🚀  Server ready at ${url} 🚀`);
-});
+startServer()

--- a/server/src/tasks/seed.js
+++ b/server/src/tasks/seed.js
@@ -1,16 +1,16 @@
 const { geocode } = require("../config/mongoCollections");
 const mongoConnection = require("../config/mongoConnection");
 const { ObjectId } = require("mongodb");
-// #MARK:- Data construction operations, does *not* do validation, that is handled in data functions
+
+// #MARK:- Data construction operations, does *not* do validation, that is handled in data functions (or programmer validation when bypassed)
 
 const createGeocodedPoint = (longitude, latitude) => {
     return {
-        // longitude: longitude,
-        // latitude: latitude,
         coordinates: [longitude, latitude],
         type: "Point"
     }
 }
+
 
 
 
@@ -24,14 +24,28 @@ async function seedDB() {
     await geocodeCollection.deleteMany({});
 
 
+    /// Arbitrarily drawn bounding box which contains all of NJ, and parts of NY, PA, DE, MD
+    const westLong = -76.223145
+    const eastLong = -73.828125
+    const southLat = 38.908133
+    const northLat = 43.317185
+
+
     try {
         console.log("Inserting points")
         const points = []
-        for(let i = 0; i < 100; i++) {
-            for(let j = 0; j < 80; j++) {
-                points.push({ location: createGeocodedPoint(i, j)})
+
+        /// Step of `0.01` generates ~10 per one mile radius in the center of the box. Steps of `0.003` or smaller can cause performance issues due to the order of growth of points
+        const step = 0.01
+        for(let longitude = westLong; longitude < eastLong; longitude += step) {
+            for(let latitude = southLat; latitude < northLat; latitude += step) {
+                points.push({ location: createGeocodedPoint(longitude, latitude)})
             }
         }
+        console.log(`Generated ${points.length} points`)
+
+
+        /// Bypass setting logic due to large size of insert
         await geocodeCollection.insertMany(points);   
 
     } catch (err) {
@@ -41,6 +55,7 @@ async function seedDB() {
         const db = await mongoConnection();
         await db.closeConnection();
         console.log("Connection closed!");
+        process.exit(0);
     }
 }
 

--- a/server/src/tasks/seed.js
+++ b/server/src/tasks/seed.js
@@ -32,11 +32,7 @@ async function seedDB() {
                 points.push({ location: createGeocodedPoint(i, j)})
             }
         }
-        await geocodeCollection.insertMany(points);
-
-
-        /// TODO: MOVE TO ACTUAL CODE
-        await geocodeCollection.createIndex( { location : "2dsphere" } )
+        await geocodeCollection.insertMany(points);   
 
     } catch (err) {
         console.error(err);

--- a/server/src/tasks/seed.js
+++ b/server/src/tasks/seed.js
@@ -1,0 +1,51 @@
+const { geocode } = require("../config/mongoCollections");
+const mongoConnection = require("../config/mongoConnection");
+const { ObjectId } = require("mongodb");
+// #MARK:- Data construction operations, does *not* do validation, that is handled in data functions
+
+const createGeocodedPoint = (longitude, latitude) => {
+    return {
+        // longitude: longitude,
+        // latitude: latitude,
+        coordinates: [longitude, latitude],
+        type: "Point"
+    }
+}
+
+
+
+async function seedDB() {
+
+    console.log("Creating connections to collections");
+    const geocodeCollection = await geocode();
+
+
+    console.log("Dropping any previous databases")
+    await geocodeCollection.deleteMany({});
+
+
+    try {
+        console.log("Inserting points")
+        const points = []
+        for(let i = 0; i < 100; i++) {
+            for(let j = 0; j < 80; j++) {
+                points.push({ location: createGeocodedPoint(i, j)})
+            }
+        }
+        await geocodeCollection.insertMany(points);
+
+
+        /// TODO: MOVE TO ACTUAL CODE
+        await geocodeCollection.createIndex( { location : "2dsphere" } )
+
+    } catch (err) {
+        console.error(err);
+    } finally {
+        console.log("Closing connection");
+        const db = await mongoConnection();
+        await db.closeConnection();
+        console.log("Connection closed!");
+    }
+}
+
+seedDB();


### PR DESCRIPTION
Overall Changes
---
- Created MongoDB integration
   - This includes the `MongoDB` package
   - `apollo-datasource-mongodb` as it is Apollo Server's recommended Mongo integration
   - Boiler plate for Mongo from CS-546
   - Geocoded locations uses a 2d sphere object. 

- Create a seed file for the data base
  - Data is seeded around the NJ area with ~10 cars per mile radius
  - Added `npm run seed` to run the file
  - File only has minimal error handling
  
- Server start-up now supports `async` data source creation
- Created inheritance tree for `GeoJSON` types to perform validation and type mapping


GraphQL Schema changes
  --- 
- Placeholder point objects created
- Created resolvers for queries and mutations
  - Query provides point in DB to allow testing of front-end integrations
  - Mutation allows for adhoc submissions of points and testing of validation logic
- Created `GeocodedLocationDataSource` to support example logic for querying locations
