### PR TITLE
Implement Pagination and integrate leaflet into search screens 

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -30,8 +30,9 @@ const Home = ({ setSidebar }) => {
         </section>
         <h2> Getting Started</h2>
         To look at vehicles for sale, there is a search bar at the top of page
-        to allow easy access. If you are interested in selling a vehicle you can{" "}
-        <Link to="add_listing"> go here</Link> to list a vehicle for sale.
+        to allow easy access. If you are interested in{" "}
+        <Link to="add_listing">selling a vehicle you can go here</Link> to list
+        a vehicle for sale.
       </main>
     </>
   );

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from "react"; // useContext
+import { Link } from "react-router-dom";
 
 const Home = ({ setSidebar }) => {
+  
   useEffect(() => {
     setSidebar([
       {
@@ -21,9 +23,16 @@ const Home = ({ setSidebar }) => {
   return (
     <>
       <h1>Home</h1>
-      <br />
-      <br />
-      <p>This is the Home page.</p>
+      <main>
+        <section>
+          Welcome to Carigslist! Carigslist is a marketplace to buy and sell
+          vehicles directly from other people.
+        </section>
+        <h2> Getting Started</h2>
+        To look at vehicles for sale, there is a search bar at the top of page
+        to allow easy access. If you are interested in selling a vehicle you can{" "}
+        <Link to="add_listing"> go here</Link> to list a vehicle for sale.
+      </main>
     </>
   );
 };

--- a/client/src/components/MapLogic/SingleVehicleMap.js
+++ b/client/src/components/MapLogic/SingleVehicleMap.js
@@ -1,0 +1,16 @@
+import React from "react";
+import VehicleMap from "./VehicleMap";
+
+const SingleVehicleMap = (props) => {
+  const { listing, zoomLevel } = props;
+
+  return (
+    <VehicleMap
+      listings={[listing]}
+      center={listing.location.coordinateArray}
+      zoomLevel={zoomLevel}
+    />
+  );
+};
+
+export default SingleVehicleMap;

--- a/client/src/components/MapLogic/SingleVehicleMap.js
+++ b/client/src/components/MapLogic/SingleVehicleMap.js
@@ -3,11 +3,12 @@ import VehicleMap from "./VehicleMap";
 
 const SingleVehicleMap = (props) => {
   const { listing, zoomLevel } = props;
+  const [lng, lat] = listing.location.coordinateArray;
 
   return (
     <VehicleMap
       listings={[listing]}
-      center={listing.location.coordinateArray}
+      center={{ lat, lng }}
       zoomLevel={zoomLevel}
     />
   );

--- a/client/src/components/MapLogic/VehicleMap.js
+++ b/client/src/components/MapLogic/VehicleMap.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { MapContainer, TileLayer} from "react-leaflet";
+import VehicleMarker from "./VehicleMarker";
+
+const VehicleMap = (props) => {
+  const { listings, center, zoomLevel } = props;
+
+  return (
+    <MapContainer
+      className="mapcontainer"
+      center={center}
+      zoom={zoomLevel}
+      scrollWheelZoom={false}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      {listings.map((e) => (
+        <VehicleMarker listing={e} />
+      ))}
+    </MapContainer>
+  );
+};
+
+export default VehicleMap;

--- a/client/src/components/MapLogic/VehicleMap.js
+++ b/client/src/components/MapLogic/VehicleMap.js
@@ -5,6 +5,9 @@ import VehicleMarker from "./VehicleMarker";
 const VehicleMap = (props) => {
   const { listings, center, zoomLevel } = props;
 
+  if (!center || !zoomLevel) {
+    throw new Error(`Not set! ${center} ${zoomLevel}`);
+  }
   return (
     <MapContainer
       className="mapcontainer"

--- a/client/src/components/MapLogic/VehicleMap.js
+++ b/client/src/components/MapLogic/VehicleMap.js
@@ -5,9 +5,6 @@ import VehicleMarker from "./VehicleMarker";
 const VehicleMap = (props) => {
   const { listings, center, zoomLevel } = props;
 
-  if (!center || !zoomLevel) {
-    throw new Error(`Not set! ${center} ${zoomLevel}`);
-  }
   return (
     <MapContainer
       className="mapcontainer"
@@ -20,7 +17,10 @@ const VehicleMap = (props) => {
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
       {listings.map((e) => (
-        <VehicleMarker listing={e} />
+        <VehicleMarker
+          listing={e}
+          key={`marker-${e.location.coordinateArray}`}
+        />
       ))}
     </MapContainer>
   );

--- a/client/src/components/MapLogic/VehicleMarker.js
+++ b/client/src/components/MapLogic/VehicleMarker.js
@@ -10,10 +10,10 @@ const VehicleMarker = (props) => {
   return (
     <Marker position={location}>
       <Popup>
-        A {listing.metadata.modelYear} {listing.metadata.make}{" "}
-        {listing.metadata.model}
+        A {listing?.metadata?.modelYear} {listing?.metadata?.make}{" "}
+        {listing?.metadata?.model}
         <br />
-        {listing.vin}
+        {listing?.vin}
       </Popup>
     </Marker>
   );

--- a/client/src/components/MapLogic/VehicleMarker.js
+++ b/client/src/components/MapLogic/VehicleMarker.js
@@ -3,8 +3,12 @@ import { Marker, Popup } from "react-leaflet";
 
 const VehicleMarker = (props) => {
   const { listing } = props;
+
+  /// Convert from mongo ordering to leaflet
+  const [lng, lat] = listing.location.coordinateArray;
+  const location = { lat, lng };
   return (
-    <Marker position={listing.location.coordinateArray}>
+    <Marker position={location}>
       <Popup>
         A {listing.metadata.modelYear} {listing.metadata.make}{" "}
         {listing.metadata.model}

--- a/client/src/components/MapLogic/VehicleMarker.js
+++ b/client/src/components/MapLogic/VehicleMarker.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { Marker, Popup } from "react-leaflet";
+
+const VehicleMarker = (props) => {
+  const { listing } = props;
+  return (
+    <Marker position={listing.location.coordinateArray}>
+      <Popup>
+        A {listing.metadata.modelYear} {listing.metadata.make}{" "}
+        {listing.metadata.model}
+        <br />
+        {listing.vin}
+      </Popup>
+    </Marker>
+  );
+};
+
+export default VehicleMarker;

--- a/client/src/components/Pagination.js
+++ b/client/src/components/Pagination.js
@@ -1,0 +1,83 @@
+/* eslint-disable no-unused-vars */
+import React, { useState } from "react";
+
+const Pagination = (props) => {
+  const { currentPage, pageSize, goToPage, totalSize } = props;
+
+  const totalPages = Math.ceil(totalSize / pageSize);
+  const shouldShowPrevious = currentPage > 0;
+  const shouldShowNext = currentPage <= totalPages;
+
+  const makeButton = (targetPage, label, className) => (
+    <button
+      type="button"
+      key={`pagination-${label}-${targetPage}`}
+      className={className}
+      onClick={(e) => {
+        e.preventDefault();
+        goToPage(targetPage);
+      }}
+    >
+      {label}
+    </button>
+  );
+
+  const spreadAmount = 2;
+  const pages = Array.from(
+    { length: 5 },
+    (_v, i) => currentPage - spreadAmount + i
+  )
+    .filter((p) => p >= 0 && p < totalPages)
+    .map((p) => ({
+      to: p,
+      text: p + 1,
+      class: `${
+        p === currentPage && parseInt(p, 10) ? "text-red-700" : ""
+      }`.trim(),
+    }));
+
+  // eslint-disable-next-line no-use-before-define
+  appendTextLabelsToArray(pages, currentPage, spreadAmount, totalPages - 1, {
+    shouldShowPrevious,
+    shouldShowNext,
+  });
+
+  const links = pages.map((i) =>
+    makeButton(i.to, i.text, `${i.class} px-10`.trim())
+  );
+
+  return <div className="flex content-center">{links}</div>;
+};
+
+const appendTextLabelsToArray = (
+  pages,
+  pageNum,
+  pageSpread,
+  lastPage,
+  data
+) => {
+  const paginationTextClass = "px-10";
+  if (pageNum - pageSpread > 0) {
+    pages.unshift({ to: 0, text: "First", class: paginationTextClass });
+  } else if (pages[0].to === 0) {
+    // eslint-disable-next-line no-param-reassign
+    pages[0].text = "First";
+  }
+  if (data.shouldShowPrevious) {
+    pages.unshift({
+      to: pageNum - 1,
+      text: "Prev",
+      class: paginationTextClass,
+    });
+  }
+
+  if (pageNum + pageSpread < lastPage) {
+    pages.push({ to: lastPage, text: "Last", class: paginationTextClass });
+  }
+
+  if (data.shouldShowNext) {
+    pages.push({ to: pageNum + 1, text: "Next", class: paginationTextClass });
+  }
+};
+
+export default Pagination;

--- a/client/src/components/Pagination.js
+++ b/client/src/components/Pagination.js
@@ -1,26 +1,12 @@
 /* eslint-disable no-unused-vars */
-import React, { useState } from "react";
+import React from "react";
 
 const Pagination = (props) => {
-  const { currentPage, pageSize, goToPage, totalSize } = props;
+  const { currentPage, pageSize, setPageSize, goToPage, totalSize } = props;
 
   const totalPages = Math.ceil(totalSize / pageSize);
   const shouldShowPrevious = currentPage > 0;
   const shouldShowNext = currentPage <= totalPages;
-
-  const makeButton = (targetPage, label, className) => (
-    <button
-      type="button"
-      key={`pagination-${label}-${targetPage}`}
-      className={className}
-      onClick={(e) => {
-        e.preventDefault();
-        goToPage(targetPage);
-      }}
-    >
-      {label}
-    </button>
-  );
 
   const spreadAmount = 2;
   const pages = Array.from(
@@ -44,11 +30,39 @@ const Pagination = (props) => {
     shouldShowNext,
   });
 
-  const links = pages.map((i) =>
-    makeButton(i.to, i.text, `${i.class} px-10`.trim())
-  );
+  const links = pages.map((i) => (
+    <button
+      type="button"
+      key={`pagination-${i.text}-${i.to}`}
+      className={`${i.class} px-10`.trim()}
+      onClick={(e) => {
+        e.preventDefault();
+        goToPage(i.to);
+      }}
+    >
+      {i.text}
+    </button>
+  ));
 
-  return <div className="flex content-center">{links}</div>;
+  return (
+    <div className="flex content-center">
+      {links}
+      <label>
+        Results per page
+        <input
+          type="number"
+          step="5"
+          min="5"
+          max="20"
+          value={pageSize}
+          onChange={(e) => {
+            e.preventDefault();
+            setPageSize(e.target.value - 0);
+          }}
+        />
+      </label>
+    </div>
+  );
 };
 
 const appendTextLabelsToArray = (

--- a/client/src/components/Pagination.js
+++ b/client/src/components/Pagination.js
@@ -32,7 +32,9 @@ const Pagination = (props) => {
       to: p,
       text: p + 1,
       class: `${
-        p === currentPage && parseInt(p, 10) ? "text-red-700" : ""
+        p === currentPage && Number.isFinite(parseInt(p, 10))
+          ? "text-red-700"
+          : ""
       }`.trim(),
     }));
 
@@ -57,12 +59,10 @@ const appendTextLabelsToArray = (
   data
 ) => {
   const paginationTextClass = "px-10";
-  if (pageNum - pageSpread > 0) {
+  if (pageNum - pageSpread > 0 || pages[0].to === 0) {
     pages.unshift({ to: 0, text: "First", class: paginationTextClass });
-  } else if (pages[0].to === 0) {
-    // eslint-disable-next-line no-param-reassign
-    pages[0].text = "First";
   }
+
   if (data.shouldShowPrevious) {
     pages.unshift({
       to: pageNum - 1,

--- a/client/src/components/find_cars/SearchCard.js
+++ b/client/src/components/find_cars/SearchCard.js
@@ -92,7 +92,7 @@ const ListingDetails = (props) => {
           <span>Interior {interiorColor} </span>
         </span>
       </div>
-      <SingleVehicleMap listing={listing} zoomLevel={3} />
+      <SingleVehicleMap listing={listing} zoomLevel={15} />
     </div>
   );
 };

--- a/client/src/components/find_cars/SearchCard.js
+++ b/client/src/components/find_cars/SearchCard.js
@@ -3,6 +3,7 @@
 import React from "react";
 
 import { Link } from "react-router-dom";
+import SingleVehicleMap from "../MapLogic/SingleVehicleMap";
 
 const SearchCard = (props) => {
   const fallbackImage = "/images/ImgNotAvailable.png";
@@ -71,8 +72,8 @@ const SearchCard = (props) => {
 
 const ListingDetails = (props) => {
   const { listing } = props;
-  const { vin, exteriorColor, interiorColor, millage, price, location } =
-    listing;
+  const { vin, exteriorColor, interiorColor, millage, price } = listing;
+  listing.location.coordinateArray = listing.location;
 
   const key = `listing-${vin}`;
   return (
@@ -91,7 +92,7 @@ const ListingDetails = (props) => {
           <span>Interior {interiorColor} </span>
         </span>
       </div>
-      Location {location}
+      <SingleVehicleMap listing={listing} zoomLevel={3} />
     </div>
   );
 };

--- a/client/src/components/find_cars/SearchResults.js
+++ b/client/src/components/find_cars/SearchResults.js
@@ -11,11 +11,10 @@ const SearchResults = (props) => {
   const [searchResults, setSearchResults] = useState([]);
 
   const [loading, setLoading] = useState(true);
-  // eslint-disable-next-line no-unused-vars
   const [page, setPage] = useState(0);
   const [totalSize, setTotalSize] = useState(null);
+  const [resultsPerPage, setResultsPerPage] = useState(10);
 
-  const resultsPerPage = 10;
   const offset = page * resultsPerPage;
 
   const {
@@ -41,9 +40,10 @@ const SearchResults = (props) => {
             { data: { metadata: data.metadata }, listing: data.listing },
           ];
         }
+      } else if (query === undefined || query === null) {
+        return;
       } else {
-        /// TODO handle garbage input
-        query.limit = 3;
+        query.limit = resultsPerPage;
         query.offset = offset;
         const { data } = await Searches.byComponents(query);
         const { pagination, results } = data;
@@ -57,7 +57,7 @@ const SearchResults = (props) => {
       setSearchResults(Array.isArray(resultsToSet) ? resultsToSet : []);
       setLoading(!Array.isArray(resultsToSet));
     })();
-  }, [state, offset]);
+  }, [state, offset, resultsPerPage]);
 
   /// TODO select the header form on click?
   if (state === undefined) {
@@ -75,6 +75,7 @@ const SearchResults = (props) => {
           <Pagination
             currentPage={page}
             pageSize={resultsPerPage}
+            setPageSize={setResultsPerPage}
             goToPage={setPage}
             totalSize={totalSize}
           />

--- a/client/src/components/find_cars/SearchResults.js
+++ b/client/src/components/find_cars/SearchResults.js
@@ -59,7 +59,6 @@ const SearchResults = (props) => {
     })();
   }, [state, offset, resultsPerPage]);
 
-  /// TODO select the header form on click?
   if (state === undefined) {
     return <div> Please enter a search term</div>;
   }

--- a/client/src/components/find_cars/SearchResults.js
+++ b/client/src/components/find_cars/SearchResults.js
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import Searches from "../../data/search";
 import SearchCard from "./SearchCard";
 import Pagination from "../Pagination";
-import { Loading } from "..";
+import Loading from "../Loading";
 
 const SearchResults = (props) => {
   const [searchResults, setSearchResults] = useState([]);

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,5 +1,3 @@
-/// TODO RESOLVE 
-/* eslint-disable import/no-cycle */
 // Analytics
 export { default as Vin } from "./analytics/Vin";
 export { default as Safety } from "./analytics/Safety";
@@ -41,5 +39,4 @@ export { default as Header } from "./Header";
 export { default as Home } from "./Home";
 export { default as ListBody } from "./ListBody";
 export { default as ListError } from "./ListError";
-export { default as Loading } from "./Loading";
 export { default as NavBar } from "./NavBar";

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,10 +1,11 @@
+/// TODO RESOLVE 
+/* eslint-disable import/no-cycle */
 // Analytics
 export { default as Vin } from "./analytics/Vin";
 export { default as Safety } from "./analytics/Safety";
 
 // Find
 export { default as SearchResults } from "./find_cars/SearchResults";
-// export { default as MiniVehicleSearchForm } from "./find_cars/MiniVehicleSearchForm";
 export { default as FindByMake } from "./find_cars/FindByMake";
 export { default as FindByModel } from "./find_cars/FindByModel";
 export { default as FindByVin } from "./find_cars/FindByVin";

--- a/client/src/components/listings/AddListing.js
+++ b/client/src/components/listings/AddListing.js
@@ -15,6 +15,7 @@ const AddListing = () => {
       setCreatedListing({ data: { metadata: data.metadata }, listing: data });
       e.target.reset();
       setErrors([]);
+      setGeoCodedData(null);
     } else if (status === 413) {
       setErrors(["Image is too large!"]);
     } else if (status >= 400 && status < 600 && data.message) {
@@ -69,8 +70,8 @@ const AddListing = () => {
 
   const geocodeAddress = async (e) => {
     e.preventDefault();
-    const address = e.target.value;
-    if (address.trim() === geocodedData?.searchedTerm) {
+    const address = e.target.value.trim();
+    if (address === geocodedData?.searchedTerm || address.length === 0) {
       return;
     }
     setGeocodeDataLoading(true);

--- a/client/src/components/listings/AddListing.js
+++ b/client/src/components/listings/AddListing.js
@@ -1,10 +1,13 @@
 import React, { useState } from "react";
-import { listing } from "../../data";
+import { listing, geocode } from "../../data";
 import SearchCard from "../find_cars/SearchCard";
+import SingleVehicleMap from "../MapLogic/SingleVehicleMap";
 
 const AddListing = () => {
   const [errors, setErrors] = useState([]);
   const [createdListing, setCreatedListing] = useState(null);
+  const [geocodedData, setGeoCodedData] = useState(null);
+  const [geocodeDataLoading, setGeocodeDataLoading] = useState(false);
 
   const uploadListing = async (newListing, e) => {
     const { data, status } = await listing.addListing(newListing);
@@ -24,13 +27,17 @@ const AddListing = () => {
   const submitHandler = async (e) => {
     e.preventDefault();
     setCreatedListing(null);
+    if (geocodeDataLoading) {
+      setErrors([
+        "Cannot submit form while Geocoded address is being looked up!",
+      ]);
+      return;
+    }
+    const { lat, lon } = geocodedData;
     const newListing = {
       exteriorColor: e.target.elements.exteriorColor.value,
       interiorColor: e.target.elements.interiorColor.value,
-      coordinates: [
-        e.target.elements.longitude.value,
-        e.target.elements.latitude.value,
-      ],
+      coordinates: [lon, lat],
       millage: e.target.elements.millage.value,
       price: e.target.elements.price.value,
       vin: e.target.elements.vin.value,
@@ -60,6 +67,33 @@ const AddListing = () => {
     };
   };
 
+  const geocodeAddress = async (e) => {
+    e.preventDefault();
+    const address = e.target.value;
+    if (address.trim() === geocodedData?.searchedTerm) {
+      return;
+    }
+    setGeocodeDataLoading(true);
+    setGeoCodedData(null);
+    setCreatedListing(null);
+
+    const { data, status } = await geocode.geocodeAddress(address);
+    if (status >= 400 || data.length === 0) {
+      setErrors(["Failed to geocode address"]);
+    } else {
+      const result = data[0];
+      setErrors([]);
+      setGeoCodedData({
+        lat: result.lat,
+        lon: result.lon,
+        displayName: result.display_name,
+        searchedTerm: address,
+      });
+    }
+
+    setGeocodeDataLoading(false);
+  };
+
   return (
     <div className="main_layout">
       <div className="mainbody">
@@ -83,38 +117,19 @@ const AddListing = () => {
               />
             </label>
 
-            <div id="coordinates" className="form-group flex-row">
-              <label>
-                Longitude
-                <input
-                  id="longitude"
-                  type="number"
-                  name="longitude"
-                  placeholder="Longitude..."
-                  step="0.0000001"
-                  min="-180"
-                  max="180"
-                  className="mx-2"
-                  title="The longitude of where the vehicle is sold"
-                  required
-                />
-              </label>
-              <label>
-                Latitude
-                <input
-                  id="latitude"
-                  type="number"
-                  name="latitude"
-                  placeholder="Latitude..."
-                  step="0.0000001"
-                  min="-90"
-                  max="90"
-                  className="mx-2"
-                  title="The longitude of where the vehicle is sold"
-                  required
-                />
-              </label>
-            </div>
+            <label>
+              Street Address
+              <input
+                id="streetAddress"
+                type="text"
+                name="streetAddress"
+                placeholder="Street address of vehicle"
+                title="Where is the vehicle located?"
+                onBlur={geocodeAddress}
+                disabled={geocodeDataLoading}
+                required
+              />
+            </label>
             <label>
               Price
               <input
@@ -187,6 +202,23 @@ const AddListing = () => {
             </p>
           ))}
         </div>
+        {geocodedData?.displayName ? (
+          <span>
+            This vehicle is at {geocodedData.displayName}
+            <br />
+            <SingleVehicleMap
+              listing={{
+                location: {
+                  coordinateArray: [geocodedData.lon, geocodedData.lat],
+                },
+              }}
+              zoomLevel="15"
+            />
+          </span>
+        ) : (
+          ""
+        )}
+
         {createdListing ? (
           <div>
             Created <br />

--- a/client/src/components/listings/AllListings.js
+++ b/client/src/components/listings/AllListings.js
@@ -38,7 +38,7 @@ const AllListings = () => {
 
   const getAveragePosition = (positions) => {
     const sm = positions.reduce(
-      (cur, pos) =>  [cur[1] + pos[1], cur[0] + pos[0]],
+      (cur, pos) => [cur[1] + pos[1], cur[0] + pos[0]],
       [0, 0]
     );
     return [sm[0] / positions.length, sm[1] / positions.length];

--- a/client/src/components/listings/AllListings.js
+++ b/client/src/components/listings/AllListings.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet"
 import { listing } from "../../data";
 import Loading from "../Loading";
+import VehicleMap from "../MapLogic/VehicleMap";
 import Pagination from "../Pagination";
 import Listing from "./ListingCard";
 
@@ -12,7 +12,7 @@ const AllListings = () => {
   const [page, setPage] = useState(0);
   const [totalSize, setTotalSize] = useState(null);
 
-  const listingPageLimit = 3;
+  const listingPageLimit = 10;
   const offset = page * listingPageLimit;
 
   useEffect(() => {
@@ -26,20 +26,23 @@ const AllListings = () => {
 
       setTotalSize(data.pagination.totalCount);
 
-      if (Math.floor(status/100) === 2 && data) {
+      if (Math.floor(status / 100) === 2 && data) {
         setListings(data.results);
       }
 
       setLoading(false);
     }
     fetchData();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [offset]);
 
   const getAveragePosition = (positions) => {
-    const sm = positions.reduce((cur, pos) => [cur[0]+pos[0], cur[1]+pos[1]], [0, 0]);
+    const sm = positions.reduce(
+      (cur, pos) => [cur[0] + pos[0], cur[1] + pos[1]],
+      [0, 0]
+    );
     return [sm[0] / positions.length, sm[1] / positions.length];
-  }
+  };
 
   if (loading) {
     return <Loading />;
@@ -49,30 +52,26 @@ const AllListings = () => {
     <div className="main_layout">
       <h1>Listings</h1>
       <br />
-      <Pagination currentPage={page} pageSize= {listingPageLimit} goToPage={setPage} totalSize={totalSize}/>
+      <Pagination
+        currentPage={page}
+        pageSize={listingPageLimit}
+        goToPage={setPage}
+        totalSize={totalSize}
+      />
       <div className="all_listings_map">
-        { listings.length !== 0 && (
-          <MapContainer className="mapcontainer" center={getAveragePosition(listings.map(ls => ls.location.coordinateArray))} zoom={4} scrollWheelZoom={false}>
-            <TileLayer
-              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-              />
-
-            { listings.map(ls => (
-              <Marker position={ls.location.coordinateArray}>
-                <Popup>
-                  A simple popup!
-                </Popup>
-              </Marker>
-            )) }
-          </MapContainer>
-        ) }
+        {listings.length !== 0 && (
+          <VehicleMap
+            listings={listings}
+            center={getAveragePosition(
+              listings.map((ls) => ls.location.coordinateArray)
+            )}
+            zoomLevel='4'
+          />
+        )}
       </div>
-      {
-        listings.map(ls => (
-          <Listing listing={ls} key={ls._id} />
-        ))
-      }
+      {listings.map((ls) => (
+        <Listing listing={ls} key={ls._id} />
+      ))}
     </div>
   );
 };

--- a/client/src/components/listings/AllListings.js
+++ b/client/src/components/listings/AllListings.js
@@ -11,16 +11,16 @@ const AllListings = () => {
   // eslint-disable-next-line no-unused-vars
   const [page, setPage] = useState(0);
   const [totalSize, setTotalSize] = useState(null);
+  const [listingsPerPage, setListingsPerPage] = useState(10);
 
-  const listingPageLimit = 10;
-  const offset = page * listingPageLimit;
+  const offset = page * listingsPerPage;
 
   useEffect(() => {
     async function fetchData() {
       setLoading(true);
 
       const { data, status } = await listing.getAllListings(
-        listingPageLimit,
+        listingsPerPage,
         offset
       );
 
@@ -34,7 +34,7 @@ const AllListings = () => {
     }
     fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [offset]);
+  }, [offset, listingsPerPage]);
 
   const getAveragePosition = (positions) => {
     const sm = positions.reduce(
@@ -54,7 +54,8 @@ const AllListings = () => {
       <br />
       <Pagination
         currentPage={page}
-        pageSize={listingPageLimit}
+        pageSize={listingsPerPage}
+        setPageSize={setListingsPerPage}
         goToPage={setPage}
         totalSize={totalSize}
       />

--- a/client/src/components/listings/AllListings.js
+++ b/client/src/components/listings/AllListings.js
@@ -2,26 +2,39 @@ import React, { useEffect, useState } from "react";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet"
 import { listing } from "../../data";
 import Loading from "../Loading";
+import Pagination from "../Pagination";
 import Listing from "./ListingCard";
 
 const AllListings = () => {
   const [loading, setLoading] = useState(true);
   const [listings, setListings] = useState([]);
+  // eslint-disable-next-line no-unused-vars
+  const [page, setPage] = useState(0);
+  const [totalSize, setTotalSize] = useState(null);
+
+  const listingPageLimit = 3;
+  const offset = page * listingPageLimit;
 
   useEffect(() => {
     async function fetchData() {
       setLoading(true);
 
-      const { data, status } = await listing.getAllListings();
+      const { data, status } = await listing.getAllListings(
+        listingPageLimit,
+        offset
+      );
+
+      setTotalSize(data.pagination.totalCount);
 
       if (Math.floor(status/100) === 2 && data) {
-        setListings(data);
+        setListings(data.results);
       }
 
       setLoading(false);
     }
     fetchData();
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [offset]);
 
   const getAveragePosition = (positions) => {
     const sm = positions.reduce((cur, pos) => [cur[0]+pos[0], cur[1]+pos[1]], [0, 0]);
@@ -31,11 +44,12 @@ const AllListings = () => {
   if (loading) {
     return <Loading />;
   }
-  console.log(listings);
+
   return (
     <div className="main_layout">
       <h1>Listings</h1>
       <br />
+      <Pagination currentPage={page} pageSize= {listingPageLimit} goToPage={setPage} totalSize={totalSize}/>
       <div className="all_listings_map">
         { listings.length !== 0 && (
           <MapContainer className="mapcontainer" center={getAveragePosition(listings.map(ls => ls.location.coordinateArray))} zoom={4} scrollWheelZoom={false}>

--- a/client/src/components/listings/AllListings.js
+++ b/client/src/components/listings/AllListings.js
@@ -8,7 +8,6 @@ import Listing from "./ListingCard";
 const AllListings = () => {
   const [loading, setLoading] = useState(true);
   const [listings, setListings] = useState([]);
-  // eslint-disable-next-line no-unused-vars
   const [page, setPage] = useState(0);
   const [totalSize, setTotalSize] = useState(null);
   const [listingsPerPage, setListingsPerPage] = useState(10);
@@ -18,6 +17,7 @@ const AllListings = () => {
   useEffect(() => {
     async function fetchData() {
       setLoading(true);
+      setListings(null);
 
       const { data, status } = await listing.getAllListings(
         listingsPerPage,
@@ -66,7 +66,7 @@ const AllListings = () => {
             center={getAveragePosition(
               listings.map((ls) => ls.location.coordinateArray)
             )}
-            zoomLevel='4'
+            zoomLevel='1'
           />
         )}
       </div>

--- a/client/src/components/listings/AllListings.js
+++ b/client/src/components/listings/AllListings.js
@@ -38,7 +38,7 @@ const AllListings = () => {
 
   const getAveragePosition = (positions) => {
     const sm = positions.reduce(
-      (cur, pos) => [cur[0] + pos[0], cur[1] + pos[1]],
+      (cur, pos) =>  [cur[1] + pos[1], cur[0] + pos[0]],
       [0, 0]
     );
     return [sm[0] / positions.length, sm[1] / positions.length];
@@ -66,7 +66,7 @@ const AllListings = () => {
             center={getAveragePosition(
               listings.map((ls) => ls.location.coordinateArray)
             )}
-            zoomLevel='1'
+            zoomLevel="1"
           />
         )}
       </div>

--- a/client/src/components/listings/ListingCard.js
+++ b/client/src/components/listings/ListingCard.js
@@ -48,7 +48,7 @@ const Listing = (props) => {
         />
         <Marker position={listing.location.coordinateArray}>
           <Popup>
-            A simple popup!
+            A {listing.metadata.modelYear} {listing.metadata.make} {listing.metadata.model} <br /> {listing.vin}
           </Popup>
         </Marker>
       </MapContainer>

--- a/client/src/components/listings/ListingCard.js
+++ b/client/src/components/listings/ListingCard.js
@@ -1,9 +1,8 @@
 import React from "react";
-import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet"
+import SingleVehicleMap from "../MapLogic/SingleVehicleMap";
 
 const Listing = (props) => {
   const { listing } = props;
-  console.log(listing);
   
   return (
     <div className="listing">
@@ -41,17 +40,7 @@ const Listing = (props) => {
           <dd>{listing.vin}</dd>
         </div>
       </dl>
-      <MapContainer className="mapcontainer" center={listing.location.coordinateArray} zoom={13} scrollWheelZoom={false}>
-        <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
-        <Marker position={listing.location.coordinateArray}>
-          <Popup>
-            A {listing.metadata.modelYear} {listing.metadata.make} {listing.metadata.model} <br /> {listing.vin}
-          </Popup>
-        </Marker>
-      </MapContainer>
+      <SingleVehicleMap listing={listing} zoomLevel="13" />
     </div>
   );
 };

--- a/client/src/data/geocoding.js
+++ b/client/src/data/geocoding.js
@@ -1,0 +1,22 @@
+import axios from "axios";
+
+async function queryUrl(url, config) {
+  return axios.get(url, {
+    ...config,
+    validateStatus: (status) => status < 500,
+  });
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export async function geocodeAddress(address) {
+  const urlSafeAddress = address
+    .trim()
+    .split(" ")
+    .filter((e) => e !== "")
+    .join("+");
+
+  const { data, status } = await queryUrl(
+    `https://nominatim.openstreetmap.org/search?format=json&q=${urlSafeAddress}&output=json`
+  );
+  return { data, status };
+}

--- a/client/src/data/index.js
+++ b/client/src/data/index.js
@@ -2,10 +2,12 @@ const nhtsaData = require("./nhtsa");
 const searchData = require("./search");
 const listingData = require("./listing");
 const accountData = require("./account");
+const geocodeData = require("./geocoding");
 
 module.exports = {
   nhtsa: nhtsaData,
   search: searchData,
   listing: listingData,
   account: accountData,
+  geocode: geocodeData,
 };

--- a/client/src/data/listing.js
+++ b/client/src/data/listing.js
@@ -36,10 +36,10 @@ export async function addListing(listing) {
   return { data, status };
 }
 
-export async function getAllListings() {
+export async function getAllListings(limit = 20, offset = 10) {
   const header = await createHeader();
   const { data, status } = await getUrl(
-    `http://localhost:3001/listing`,
+    `http://localhost:3001/listing?limit=${limit}&offset=${offset}`,
     header
   );
   return { data, status };

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -6,6 +6,8 @@ const { nhtsa } = require("../api");
 const { insertListing, 
     countFromMetadata,
     listingsWithinMileRadius, 
+    uploadPhotoForVin,
+    listingForVin,
     getAllListings, 
     getUserListings } = require('../src/MongoOperations/listing');
 const { KeyAlreadyExists } = require('../src/MongoOperations/OperationErrors');

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -10,6 +10,7 @@ const { insertListing,
     getUserListings } = require('../src/MongoOperations/listing');
 const { KeyAlreadyExists } = require('../src/MongoOperations/OperationErrors');
 const GeoJsonPoint = require('../src/DataModel/GeoJson/GeoJsonPoint');
+const PaginationRequest = require('../src/PaginationRequest');
 
 router.get('/', async (req, res) => {
     const userid = req.currentUser?.user_id;
@@ -21,9 +22,15 @@ router.get('/', async (req, res) => {
         data = await getUserListings(userid);
         totalCount = data.length
     } else {
-        const limit = req.query.limit  > 0 ? parseInt(req.query.limit ) : 100;
-        const offset = req.query.offset >= 0 ? parseInt(req.query.offset) : 0;
-        data = await getAllListings(limit, offset);
+        let paginationRequest;
+        try {
+            paginationRequest = new PaginationRequest(req.query);
+        } catch (e) {
+            console.error(e);
+            return res.status(400).json({message: e.message});
+        }
+        
+        data = await getAllListings(paginationRequest);
         totalCount = await countFromMetadata();
     }
     

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -21,9 +21,9 @@ router.get('/', async (req, res) => {
         data = await getUserListings(userid);
         totalCount = data.length
     } else {
-        /// TODO VALIDATE
-        const { limit, offset } = req.query;
-        data = await getAllListings(limit - 0, offset - 0);
+        const limit = req.query.limit  > 0 ? parseInt(req.query.limit ) : 100;
+        const offset = req.query.offset >= 0 ? parseInt(req.query.offset) : 0;
+        data = await getAllListings(limit, offset);
         totalCount = await countFromMetadata();
     }
     

--- a/server/routes/listings.js
+++ b/server/routes/listings.js
@@ -3,25 +3,36 @@ const router = express.Router();
 const VehicleListing = require('../src/DataModel/Automotive/VehicleListing');
 const { ValidationError, validateNonBlankString } = require('../src/DataModel/Validation/ObjectProperties');
 const { nhtsa } = require("../api");
-const { insertListing, listingsWithinMileRadius, getAllListings, getUserListings } = require('../src/MongoOperations/listing');
+const { insertListing, 
+    countFromMetadata,
+    listingsWithinMileRadius, 
+    getAllListings, 
+    getUserListings } = require('../src/MongoOperations/listing');
 const { KeyAlreadyExists } = require('../src/MongoOperations/OperationErrors');
 const GeoJsonPoint = require('../src/DataModel/GeoJson/GeoJsonPoint');
 
 router.get('/', async (req, res) => {
     const userid = req.currentUser?.user_id;
     let data;
-    
+    let totalCount;
     if (req.query.user === 'true') {
         if (!userid)
         return res.status(401).json({ message: 'You must be logged in to view user listings' });
         data = await getUserListings(userid);
+        totalCount = data.length
     } else {
-        data = await getAllListings();
+        /// TODO VALIDATE
+        const { limit, offset } = req.query;
+        data = await getAllListings(limit - 0, offset - 0);
+        totalCount = await countFromMetadata();
     }
     
-    // console.log('userid', userid);
-    // console.log('data', data);
-    res.json(data);
+    res.json({
+        pagination: {
+            totalCount
+        },
+        results: data
+    });
 });
 /**
  * Route to get all listings within a specified radius

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -2,7 +2,7 @@ const express = require('express');
 const { nhtsa } = require('../api');
 const router = express.Router();
 const { listingForVin, searchListings } = require('../src/MongoOperations/listing');
-
+const  PaginationRequest  = require('../src/PaginationRequest');
 
 router.get('/by/vin/:vin', async (req, res) => {
     const vin = req.params.vin
@@ -46,9 +46,22 @@ router.get('/by/components', async (req, res) => {
         return res.status(400).json({message: `One of ${validKeys} must be present`})
     }
 
+    let paginationRequest;
+    try {
+        paginationRequest = new PaginationRequest(req.query);
+    } catch (e) {
+        console.error(e);
+        return res.status(400).json({message: e.message});
+    }
 
-    const data = await searchListings(query);
-    res.json(data.map(e => e.asDictionary()))
+
+    const {totalSize, results} = await searchListings(query, paginationRequest);
+    res.json({
+        pagination: {
+            totalSize
+        },
+        results: results.map(e => e.asDictionary())
+    })
 
 })
 

--- a/server/src/DataModel/Validation/ObjectProperties.js
+++ b/server/src/DataModel/Validation/ObjectProperties.js
@@ -36,6 +36,11 @@ const validateNonNegativeInteger = (int) => {
     return int - 0;
 }
 
+const validatePositiveInteger = (int) => {
+    if(!Number.isInteger(int - 0 ) || int <= 0) { throw new ValidationError("integer", "must be non-negative")}
+    return int - 0;
+}
+
 const validatePositiveFloat = (float) => {
     if(!isFinite(float) || float <= 0) { throw new ValidationError("float", "must be positive") }
     return float - 0;
@@ -62,6 +67,7 @@ module.exports = {
     ValidationError,
     validateNonBlankString,
     validateNullOrNonBlankString,
+    validatePositiveInteger,
     validateNonNegativeInteger,
     validatePositiveFloat,
     validateIsObjectId,

--- a/server/src/MongoOperations/listing.js
+++ b/server/src/MongoOperations/listing.js
@@ -32,9 +32,24 @@ const parseMakeModelForQuery = (query, operator="$and") => {
 
 }
 
-async function getAllListings() {
+/// Get the size of collection from its metadata. 
+/// Note: While this function may be skewed, without sharding or a forced shutdown it should be accurate per the docs
+const countFromMetadata = async () => {
     const collection = await listings();
-    const listingData = await collection.find({}).toArray()
+    return await collection.count();
+}
+
+async function getAllListings(limit=20, offset=0) {
+    if(!Number.isInteger(limit) || !Number.isInteger(offset) || 
+    limit < 0 || offset < 0 ){
+        throw new Error("Invalid limit or offset");
+    }
+
+    const collection = await listings();
+    const listingData = await collection.find({})
+    .skip(offset)
+    .limit(limit)
+    .toArray()
     return listingData.map(e => new VehicleListing(e));
 }
 
@@ -148,6 +163,7 @@ const listingsWithinRadianRadius = async (centerPoint, radius) => {
 
 module.exports = {
     listingForVin,
+    countFromMetadata,
     getAllListings,
     getUserListings,
     searchListings,

--- a/server/src/MongoOperations/listing.js
+++ b/server/src/MongoOperations/listing.js
@@ -3,7 +3,7 @@ const VehicleListing = require('../DataModel/Automotive/VehicleListing')
 const { InternalMongoError, KeyAlreadyExists } = require('./OperationErrors');
 const { ValidationError } = require('../DataModel/Validation/ObjectProperties');
 const GeoJsonPoint = require('../DataModel/GeoJson/GeoJsonPoint');
-const { uploadImage} = require('./imageUploads');
+const { uploadImage } = require('./imageUploads');
 const PaginationRequest = require('../PaginationRequest');
 
 const listingForVin = async (vin) => {

--- a/server/src/MongoOperations/listing.js
+++ b/server/src/MongoOperations/listing.js
@@ -103,10 +103,12 @@ const searchListings = async (query, paginationRequest) => {
 
 
 const uploadPhotoForVin = async (vin, photo) => {
-    if (typeof photo !== 'string' || typeof vin !== 'string') { return false; }
+    if (typeof photo !== 'string' || typeof vin !== 'string') { 
+        throw new Error(`Vin or photo is not a string.${vin} ${typeof photo}`)
+     }
 
     const listing = await listingForVin(vin);
-    if (!listing) { return false; }
+    if (!listing) { throw new Error("Listing not found!") }
 
     
     const collection = await listings();
@@ -115,11 +117,13 @@ const uploadPhotoForVin = async (vin, photo) => {
         if(_id == null || filename == null) {
             throw new Error(`One required field null! ${_id} ${filename}`);
         }
-        collection.updateOne(
+
+        await collection.updateOne(
             { vin: vin },
             { $set: {"photo": {_id, filename}}}
         )
-        return null;
+
+        return {_id, filename};
     } catch (e) {
         console.error(`Failed to upload image: ${e}`);
         throw e;

--- a/server/src/MongoOperations/listing.js
+++ b/server/src/MongoOperations/listing.js
@@ -85,7 +85,6 @@ const searchListings = async (query, paginationRequest) => {
     .find({$and: formattedQuery})
 
     const count = await searchCursor.count()
-    console.log(count);
 
     const listingData = (await searchCursor
                         .skip(offset)

--- a/server/src/PaginationRequest.js
+++ b/server/src/PaginationRequest.js
@@ -1,0 +1,10 @@
+const {applyValidation, validateNonNegativeInteger, validatePositiveInteger } = require("./DataModel/Validation/ObjectProperties")
+class PaginationRequest {
+    constructor(dictionary, defaultLimit = 10) {
+        const {limit, offset} = dictionary
+        applyValidation(["limit"], {limit: limit || defaultLimit}, validatePositiveInteger, this);
+        applyValidation(["offset"], {offset: offset || 0 }, validateNonNegativeInteger, this);
+    }
+}
+
+module.exports = PaginationRequest;


### PR DESCRIPTION
- Pagination object created to show pages based on passed in props
    - Handles rendering the UI and binding onClicks
    - Component handles choosing the size of the page
- Server updated to vend pagination information
- Client logic parses this pagination info
- Client now requests listings via pagination on search and all listings
- Leaflet logic moved into own components, and large maps zoomed out
   - Normalized conversions between server [Long, lat] and client [lat, lng]
- Implemented basic home page blurb 
- Listing form can now Geocode via `nominatim.openstreetmap`, leaflet maps give proper accreditation 
-  Resolved missing `await` on image uploading which could cause the client not to see image data.